### PR TITLE
백준 3745 오름세 문제 풀이

### DIFF
--- a/src/codingtest/Baekjoon_3745.java
+++ b/src/codingtest/Baekjoon_3745.java
@@ -1,0 +1,52 @@
+package codingtest;
+
+import java.io.*;
+import java.util.*;
+
+// 오름세: https://www.acmicpc.net/problem/3745
+// LIS, 이분탐색
+public class Baekjoon_3745 {
+    static int[] lis;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        String line = null;
+        while ((line = br.readLine()) != null) {
+            int n = Integer.parseInt(line.trim());
+            int[] arr = new int[n];
+            lis = new int[n];
+            StringTokenizer st = new StringTokenizer(br.readLine().trim());
+            for (int i = 0; i < n; i++) {
+                arr[i] = Integer.parseInt(st.nextToken());
+            }
+
+            lis[0] = arr[0];
+            int idx = 0;
+            for (int i = 1; i < n; i++) {
+                if (lis[idx] < arr[i]) {
+                    lis[++idx] = arr[i];
+                } else {
+                    lis[binarySearch(arr[i], idx)] = arr[i];
+                }
+            }
+            sb.append(idx + 1).append('\n');
+        }
+        br.close();
+        System.out.print(sb);
+    }
+
+    public static int binarySearch(int target, int end) {
+        int start = 0;
+        int mid;
+        while (start < end) {
+            mid = (start + end) / 2;
+            if (lis[mid] < target) {
+                start = mid + 1;
+            } else {
+                end = mid;
+            }
+        }
+        return end;
+    }
+}


### PR DESCRIPTION
### [문제](https://www.acmicpc.net/problem/3745)
n일 동안의 주가를 나열했을 때, 가장 긴 오름세를 구하는 문제
여기서 오름세는 아래를 의미함

<img width="222" alt="image" src="https://github.com/sseung416/AlgorithmStudy/assets/62925473/626b7c0d-a933-4e5d-998d-76ff8151b7a1">


### 해결 방안
전형적인 LIS 문제라서 풀이는 금방 생각함
다만 입력 값의 범위가 100,000이기 때문에 시간복잡도가 `O(n^2)`인 DP 방식 풀이는 시간초과가 우려되어 이분탐색을 사용해 풀이함

그러나.. 분명 올바르게 작성했는데 코드 제출하니 RuntimeException...
그래서 삽질 좀 하다가 [질문 게시판](https://www.acmicpc.net/board/view/21976)을 보니, 문제 테스트 케이스 뒤 쪽에 공백이 있는 것 같다고..
이렇게.. `1 `, 그래서 이 int 값으로 형변환 하기 전에 위 질문 게시판의 코드와 동일하게 `trim()` 처리 후에 변환했음

잘 됩니다 ㅎㅎ 그나저나 저 글 없었으면 눈물만 흘리고 있었을 듯하다..
