### PR TITLE
백준 25682 체스판 다시 칠하기 2 문제

### DIFF
--- a/src/codingtest/Baekjoon_1018.java
+++ b/src/codingtest/Baekjoon_1018.java
@@ -3,7 +3,8 @@ package codingtest;
 import java.io.*;
 import java.util.*;
 
-// 체스판 다시 기칠하기: https://www.acmicpc.net/problem/1018
+// 체스판 다시 칠하기: https://www.acmicpc.net/problem/1018
+// 완전탐기
 public class Baekjoon_1018 {
     public static void main(String[] args) {
         try {

--- a/src/codingtest/Baekjoon_25682.java
+++ b/src/codingtest/Baekjoon_25682.java
@@ -1,0 +1,53 @@
+package codingtest;
+
+import java.io.*;
+import java.util.*;
+
+// 체스판 다시 칠하기 2: https://www.acmicpc.net/problem/25682
+// 누적합
+// 장하다 해냈다!!
+public class Baekjoon_25682 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        int k = Integer.parseInt(st.nextToken());
+        char[][] board = new char[n][m];
+        int[][] sum = new int[n + 1][m + 1];
+
+        char startColor = 'W';
+        for (int i = 0; i < n; i++) {
+            String line = br.readLine();
+            for (int j = 0; j < m; j++) {
+                board[i][j] = line.charAt(j);
+
+                // 누적합 계산 (칠해야 하는 칸 수)
+                sum[i + 1][j + 1] = sum[i][j + 1] + sum[i + 1][j] - sum[i][j];
+                // 현재 인덱스가 홀수인지 판단하는 함수
+                boolean isOddIdx = j % 2 == 1;
+                // 현재 값이 체스판의 올바른 형태가 아니라면, 칠해야 하는 개수를 증가해줌
+                if ((startColor == board[i][j] && !isOddIdx) || (startColor != board[i][j] && isOddIdx)) {
+                    sum[i + 1][j + 1]++;
+                }
+            }
+            startColor = startColor == 'W' ? 'B' : 'W';
+        }
+
+        br.close();
+
+        // 계산
+        int min = Integer.MAX_VALUE;
+        for (int startX = 1; startX + k - 1 <= n; startX++) { // k x k 체스판으로 쪼개기
+            for (int startY = 1; startY + k - 1 <= m; startY++) {
+                int endX = startX + k - 1;
+                int endY = startY + k - 1;
+
+                int count = sum[endX][endY] - sum[endX][startY - 1] - sum[startX - 1][endY] + sum[startX - 1][startY - 1];
+                min = Math.min(min, count);
+                min = Math.min(min, k * k - count);
+            }
+        }
+        System.out.println(min);
+    }
+}


### PR DESCRIPTION
### [문제](https://www.acmicpc.net/problem/25682)
n * m의 체스판이 있을 때, k * k 크기의 체스판으로 만들려고 함
어디를 잘라도 되는데, 칠해야 하는 색상이 가장 적은 경우를 구해야 함

### 해결방안
체스판 다시 칠하기 1 문제는 완탐으로 풀었는데, 체스판의 크기가 최대 `2000 * 2000`이므로, 완탐으로 풀면 최악의 경우 `2000 * 2000 * 2000 = 8,000,000,000` 8억으로 당연히 시간초과 난다
무슨 알고리즘으로 풀어야 할지 감이 안 잡혀 확인하니 누적합이라서.. 누적합으로 풀이했다

체스판 다시 칠하기 1 문제의 구현에 단순히 누적합 부분만 추가했다
누적합의 기준은 **페인트를 칠해야 할 사각형의 개수**로 잡았다

첫 번째 값을 체스판의 시작 색상으로 지정하고 체스판 배열을 순회하면서, 현재 인덱스가 홀수이냐 짝수이냐에 따라서 분기 처리했다
현재 인덱스(`j`)가 홀수이고 시작 색상과 같을 때와 현재 인덱스가 짝수이고 시작 색상과 다를 때, 페인트를 칠해야 하는 개수를 증가해주었다
그리고 `i`가 증가할 때마다 start color를 바꾸어 주었다 (B->W, W->B)

<img src="https://github.com/sseung416/AlgorithmStudy/assets/62925473/8411ad55-44ec-494a-949f-1173fd4fc2a0" width=500 />


계산은 그냥.. 2차원 배열 누적합 구하기..
다만 약간의 시뮬을 추가한.. 근데 이 부분을 구현 못해서 다시 칠하기 1에서 작성한 코드를 참고했다

대충.. 배열을 순회하면서 k * k 체스판 중 가장 작은 구간합이 작은 경우를 구하여 저장했다
```java
min = Math.min(min, count);
min = Math.min(min, k * k - count); // 시작 페인트의 반대인 경우의 수를 구하기 위함
```

### 기타
시뮬이 너무 약해서 한탄스럽다... 며칠 날 잡고 폐관 수련 각임..